### PR TITLE
Add blended logo

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -79,3 +79,27 @@
   -webkit-box-orient: vertical;
   overflow: hidden;
 }
+
+/* Logo styling for better blending */
+.herbally-logo {
+  transition: all 0.3s ease;
+}
+
+.herbally-logo:hover {
+  transform: scale(1.05);
+  filter: drop-shadow(0 4px 8px rgba(45, 74, 43, 0.15));
+}
+
+/* Dark mode logo adjustments */
+.dark .herbally-logo-navbar {
+  filter: brightness(0.9) contrast(1.1);
+}
+
+.dark .herbally-logo-footer {
+  filter: brightness(0) invert(1) opacity(0.9);
+}
+
+/* Light mode footer logo */
+.herbally-logo-footer {
+  filter: brightness(0) invert(1);
+}

--- a/components/footer.tsx
+++ b/components/footer.tsx
@@ -1,4 +1,5 @@
 import Link from "next/link"
+import Image from "next/image"
 import { Leaf, Phone, Mail, MapPin, Clock } from "lucide-react"
 
 const strains = ["White Widow", "Blue Dream", "Girl Scout Cookies", "OG Kush", "Sour Diesel", "Purple Haze"]
@@ -11,10 +12,13 @@ export function Footer() {
           {/* Company Info */}
           <div className="space-y-4">
             <div className="flex items-center space-x-2">
-              <div className="bg-green-600 p-2 rounded-full">
-                <Leaf className="h-6 w-6 text-white" />
-              </div>
-              <span className="text-xl font-bold">Herbally</span>
+              <Image 
+                src="/images/herbally-logo-compact.svg" 
+                alt="Herbally Logo" 
+                width={120} 
+                height={36} 
+                className="h-auto max-h-9 w-auto herbally-logo herbally-logo-footer" 
+              />
             </div>
             <p className="text-gray-300 text-sm">
               South Africa's premier cannabis community offering premium products, education, and VSC membership

--- a/components/navbar.tsx
+++ b/components/navbar.tsx
@@ -31,7 +31,13 @@ export function Navbar() {
     <header className="sticky top-0 z-50 w-full border-b bg-white/90 backdrop-blur-sm dark:border-gray-800 dark:bg-gray-950/90">
       <div className="container flex h-16 items-center justify-between px-4 md:px-6">
         <Link href="/" className="flex items-center gap-2 text-lg font-semibold" prefetch={false}>
-          <Image src="/images/herbally-logo.jpeg" alt="Herbally Logo" width={120} height={40} className="h-auto" />
+          <Image 
+            src="/images/herbally-logo-compact.svg" 
+            alt="Herbally Logo" 
+            width={160} 
+            height={48} 
+            className="h-auto max-h-12 w-auto herbally-logo herbally-logo-navbar" 
+          />
           <span className="sr-only">Herbally</span>
         </Link>
         <nav className="hidden items-center gap-6 text-sm font-medium md:flex">

--- a/public/images/herbally-logo-compact.svg
+++ b/public/images/herbally-logo-compact.svg
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 200 60" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <!-- Gradient for elegant styling -->
+    <linearGradient id="compactTextGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#2d4a2b;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1a2e19;stop-opacity:1" />
+    </linearGradient>
+    
+    <!-- Simplified cannabis leaf -->
+    <g id="compactLeaf">
+      <path d="M0,5 Q1,4 2,4.5 Q3,3.5 4,4.5 Q5,3 6,4.5 Q7,3.5 8,4.5 Q9,4 10,5 Q9,6 8,5.5 Q7,6.5 6,5.5 Q5,7 4,5.5 Q3,6.5 2,5.5 Q1,6 0,5 Z" 
+            fill="currentColor" opacity="0.7"/>
+    </g>
+  </defs>
+  
+  <!-- Left decorative elements -->
+  <g transform="translate(10,25)" color="#2d4a2b">
+    <use href="#compactLeaf" transform="scale(0.8) rotate(-15)"/>
+    <use href="#compactLeaf" transform="translate(8,0) scale(0.6) rotate(15)"/>
+  </g>
+  
+  <!-- Main Herbally text -->
+  <text x="100" y="35" text-anchor="middle" font-family="serif" font-size="24" font-weight="bold" fill="url(#compactTextGradient)">
+    Herbally
+  </text>
+  
+  <!-- Subtitle -->
+  <text x="100" y="48" text-anchor="middle" font-family="serif" font-size="8" font-weight="600" fill="#2d4a2b" letter-spacing="1px" opacity="0.8">
+    VERY SPECIAL CHRONIC
+  </text>
+  
+  <!-- Right decorative elements -->
+  <g transform="translate(170,25)" color="#2d4a2b">
+    <use href="#compactLeaf" transform="scale(0.8) rotate(15)"/>
+    <use href="#compactLeaf" transform="translate(-8,0) scale(0.6) rotate(-15)"/>
+  </g>
+  
+  <!-- Small decorative dots -->
+  <circle cx="75" cy="20" r="1" fill="#2d4a2b" opacity="0.5"/>
+  <circle cx="125" cy="20" r="1" fill="#2d4a2b" opacity="0.5"/>
+</svg>

--- a/public/images/herbally-logo.svg
+++ b/public/images/herbally-logo.svg
@@ -1,0 +1,104 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg viewBox="0 0 400 300" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <!-- Gradient for elegant styling -->
+    <linearGradient id="textGradient" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" style="stop-color:#2d4a2b;stop-opacity:1" />
+      <stop offset="100%" style="stop-color:#1a2e19;stop-opacity:1" />
+    </linearGradient>
+    
+    <!-- Cannabis leaf pattern -->
+    <g id="cannabisLeaf">
+      <path d="M0,10 Q2,8 4,9 Q6,7 8,9 Q10,6 12,9 Q14,7 16,9 Q18,8 20,10 Q18,12 16,11 Q14,13 12,11 Q10,14 8,11 Q6,13 4,11 Q2,12 0,10 Z" 
+            fill="currentColor" opacity="0.6"/>
+    </g>
+    
+    <!-- Decorative vine -->
+    <g id="vine">
+      <path d="M0,0 Q10,5 20,0 Q30,5 40,0" stroke="currentColor" stroke-width="1" fill="none" opacity="0.5"/>
+    </g>
+  </defs>
+  
+  <!-- Background -->
+  <rect width="400" height="300" fill="#f8f9fa" opacity="0"/>
+  
+  <!-- Ornate border frame -->
+  <rect x="20" y="20" width="360" height="260" rx="15" fill="none" stroke="#2d4a2b" stroke-width="2" opacity="0.3"/>
+  <rect x="30" y="30" width="340" height="240" rx="10" fill="none" stroke="#2d4a2b" stroke-width="1" opacity="0.2"/>
+  
+  <!-- Corner decorative elements -->
+  <g transform="translate(40,40)" color="#2d4a2b">
+    <use href="#cannabisLeaf" transform="rotate(-45)"/>
+    <use href="#cannabisLeaf" transform="translate(10,5) rotate(-30)"/>
+  </g>
+  
+  <g transform="translate(340,40)" color="#2d4a2b">
+    <use href="#cannabisLeaf" transform="rotate(45)"/>
+    <use href="#cannabisLeaf" transform="translate(-10,5) rotate(30)"/>
+  </g>
+  
+  <g transform="translate(40,230)" color="#2d4a2b">
+    <use href="#cannabisLeaf" transform="rotate(-135)"/>
+    <use href="#cannabisLeaf" transform="translate(10,-5) rotate(-150)"/>
+  </g>
+  
+  <g transform="translate(340,230)" color="#2d4a2b">
+    <use href="#cannabisLeaf" transform="rotate(135)"/>
+    <use href="#cannabisLeaf" transform="translate(-10,-5) rotate(150)"/>
+  </g>
+  
+  <!-- Side cannabis leaf decorations -->
+  <g transform="translate(60,80)" color="#2d4a2b">
+    <use href="#cannabisLeaf" transform="scale(1.2)"/>
+    <use href="#cannabisLeaf" transform="translate(0,20) scale(0.8)"/>
+    <use href="#cannabisLeaf" transform="translate(0,35) scale(1.1)"/>
+    <use href="#cannabisLeaf" transform="translate(0,55) scale(0.9)"/>
+    <use href="#cannabisLeaf" transform="translate(0,70) scale(1.0)"/>
+  </g>
+  
+  <g transform="translate(320,80)" color="#2d4a2b">
+    <use href="#cannabisLeaf" transform="scale(1.2) rotate(180)"/>
+    <use href="#cannabisLeaf" transform="translate(0,20) scale(0.8) rotate(180)"/>
+    <use href="#cannabisLeaf" transform="translate(0,35) scale(1.1) rotate(180)"/>
+    <use href="#cannabisLeaf" transform="translate(0,55) scale(0.9) rotate(180)"/>
+    <use href="#cannabisLeaf" transform="translate(0,70) scale(1.0) rotate(180)"/>
+  </g>
+  
+  <!-- Top decorative text -->
+  <text x="200" y="70" text-anchor="middle" font-family="serif" font-size="12" font-style="italic" fill="#2d4a2b" opacity="0.8">
+    Marijuanas Finest
+  </text>
+  <text x="200" y="85" text-anchor="middle" font-family="serif" font-size="10" font-style="italic" fill="#2d4a2b" opacity="0.6">
+    1755
+  </text>
+  
+  <!-- Main Herbally text -->
+  <text x="200" y="140" text-anchor="middle" font-family="serif" font-size="42" font-weight="bold" fill="url(#textGradient)">
+    Herbally
+  </text>
+  
+  <!-- Subtitle -->
+  <text x="200" y="165" text-anchor="middle" font-family="serif" font-size="14" font-weight="600" fill="#2d4a2b" letter-spacing="2px">
+    VERY SPECIAL
+  </text>
+  <text x="200" y="185" text-anchor="middle" font-family="serif" font-size="18" font-weight="600" fill="#2d4a2b" letter-spacing="3px">
+    CHRONIC
+  </text>
+  
+  <!-- Bottom decorative vines -->
+  <g transform="translate(80,220)" color="#2d4a2b">
+    <use href="#vine" transform="scale(2,1)"/>
+    <use href="#vine" transform="translate(0,5) scale(2.2,1)"/>
+  </g>
+  
+  <g transform="translate(80,240)" color="#2d4a2b">
+    <use href="#vine" transform="scale(2,1)"/>
+    <use href="#vine" transform="translate(0,5) scale(2.2,1)"/>
+  </g>
+  
+  <!-- Additional decorative elements -->
+  <circle cx="120" cy="110" r="2" fill="#2d4a2b" opacity="0.4"/>
+  <circle cx="280" cy="110" r="2" fill="#2d4a2b" opacity="0.4"/>
+  <circle cx="110" cy="200" r="1.5" fill="#2d4a2b" opacity="0.3"/>
+  <circle cx="290" cy="200" r="1.5" fill="#2d4a2b" opacity="0.3"/>
+</svg>


### PR DESCRIPTION
Add Herbally logos and integrate them into the navbar and footer with appropriate blending styles.

Two SVG versions of the logo (full and compact) were created. The compact version is used in the navbar and footer, with custom CSS added to `globals.css` to ensure proper scaling, hover effects, and dark/light mode compatibility for seamless integration.